### PR TITLE
Add logback file to prevent un-needed exceptions being printed to console when running unit tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ lazy val microservice = Project("uknw-auth-checker-api-stub", file("."))
   .settings(resolvers += Resolver.jcenterRepo)
   .settings(CodeCoverageSettings.settings *)
 
+Test / javaOptions += "-Dlogger.resource=logback-test.xml"
+
 lazy val it = project
   .enablePlugins(PlayScala)
   .dependsOn(microservice % "test->test")

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<configuration>
+    <logger name="STDOUT" level="ERROR"/>
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION


Before:

![image](https://github.com/user-attachments/assets/ebaf0568-40bc-4cbf-8bce-d3c5d835c6ee)

After:

![image](https://github.com/user-attachments/assets/29d8114d-2a16-438a-a7c8-1f27f8efbe3a)
